### PR TITLE
Fix #14 : Explicitly check when language auto detection is needed

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -73,7 +73,7 @@ export namespace api {
 		if (settings.disabledRules)
 			params.disabledRules = settings.disabledRules;
 
-		if (language == null)
+		if (lang == 'auto')
 			params.preferredVariants = Object.values(settings.languageVariety).join(',');
 
 		if (settings.apikey && settings.username) {


### PR DESCRIPTION
`languagetool-server` was refusing requests when static language was configured with preferred variants.

Changed the condition to explicitly check when auto detections is needed when setting preferred variants parameter.