### PR TITLE
Fix LanguageTool settings: show all supported languages in Mother tongue dropdown

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -396,7 +396,7 @@ export class LTSettingsTab extends PluginSettingTab {
                             Object.fromEntries(
                                 // only languages that are not dialects
                                 languages
-                                    .filter(v => v.longCode == v.code)
+                                    .filter(v => v.longCode === v.code || v.longCode.startsWith(v.code + "-"))
                                     .map(v => [v.longCode, v.name]),
                             ),
                         )


### PR DESCRIPTION
### Summary
The Mother tongue dropdown previously filtered out many valid languages because it only included entries where `longCode == code`.  
As a result, languages like Polish (pl-PL) and many others were missing from the list.

### Change
The filter now includes all languages where `longCode === code` **or** `longCode` starts with `code + "-"`.  
This makes the dropdown display all supported base and regional languages returned by the API.

### Testing
- Built and tested locally in Obsidian.
- Polish (pl-PL) now appears and selection persists.
- Verified that additional valid languages also show up.

### Notes
This fix restores a full and accurate language list for the Mother tongue setting.
