### PR TITLE
Fix soft-break stripping first char of next line

### DIFF
--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -249,7 +249,13 @@ function addLines(text: string, parsed: string, output: AnnotatedText) {
         const line = reminder[i];
         const pline = premider[i];
 
-        let indent = line.length - pline.length;
+        // mdast strips trailing whitespace from each line of a soft-broken
+        // paragraph, so a stray trailing space on `line` would make `line`
+        // one character longer than `pline` and the diff would be wrongly
+        // treated as a leading indent — eating the first character of the
+        // next line on the way through `line.substring(indent)`.
+        const lineForIndent = line.replace(/[ \t]+$/, "");
+        let indent = lineForIndent.length - pline.length;
         for (const m of line.matchAll(ESCAPE)) {
             indent -= 1; // each escape character is one longer
         }

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -64,6 +64,22 @@ describe("markdown parsing", () => {
         expect(annotations.annotations[3]).toStrictEqual({ text: "world" });
     });
 
+    test("soft break with trailing whitespace keeps next line intact", () => {
+        // mdast strips trailing whitespace from each line of a soft-broken
+        // paragraph. addLines must not interpret that length diff as a
+        // leading indent, otherwise it would drop the first character of
+        // the next line — observed in the wild as "We" becoming "e",
+        // "However" becoming "owever", etc. (see #22).
+        let input = "First sentence. \nWe realised that.";
+        let syntax = new SyntaxTree(input);
+        let { annotations } = syntax.annotate(undefined);
+        let logical = annotations.annotations
+            .map(a => "text" in a ? a.text : (a.interpretAs ?? ""))
+            .join("");
+        expect(logical).toContain("We realised");
+        expect(logical).not.toContain("\ne realised");
+    });
+
     test("many escapes", () => {
         let input = `\\!\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\\`\\{\\|\\}\\~`;
         let syntax = new SyntaxTree(input);


### PR DESCRIPTION
## Problem

`addLines` in `src/markdown/parser.ts` computes indent as `line.length - pline.length`. mdast strips trailing whitespace from each line of a soft-broken paragraph, so a stray trailing space on a source line makes raw and parsed differ by 1 character — the diff gets treated as a leading indent and `line.substring(indent)` swallows the first character of the next line.

In the LT annotation the plugin builds, this turns:

```
We realised that the design... → e realised that the design...
However, the project manager... → owever, the project manager...
```

Downstream that triggers wrong capitalise-sentence-start matches in any setup where the source has a trailing space before a soft break (common in Obsidian when typing prose).

## Fix

Strip trailing whitespace from `line` before computing indent. Existing escape adjustment is unchanged.

```ts
const lineForIndent = line.replace(/[ \t]+$/, "");
let indent = lineForIndent.length - pline.length;
```

## Diff

`src/markdown/parser.ts`: +7 / -1 (one new local + comment, one line changed).
`src/test/markdown.test.ts`: one regression test inside the existing describe block.

All 33 tests pass (`bun test`).

## Status

Draft while I verify whether this also covers #22 (similar symptom — false capitalise-sentence-start match — but the trigger reported there narrowed to "before footnotes", which I haven't isolated yet). The fix here is independently correct for the trailing-whitespace soft-break case described above.